### PR TITLE
fix Makefile to include path to audioconv64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BlockBlast64.z64: $(BUILD_DIR)/BlockBlast64.dfs
 BlockBlast64.z64: N64_ED64ROMCONFIGFLAGS=-w eeprom4k
 
 $(AUDIO_OUTPUT_FILES): $(AUDIO_FILES)
-	audioconv64 -o filesystem/audio/ $(AUDIO_DIR)/$(subst .ym64,.ym,$(subst .xm64,.xm,$(subst .wav64,.wav,$(notdir $@))))
+	$(N64_INST)/bin/audioconv64 -o filesystem/audio/ $(AUDIO_DIR)/$(subst .ym64,.ym,$(subst .xm64,.xm,$(subst .wav64,.wav,$(notdir $@))))
 
 
 $(BUILD_DIR)/BlockBlast64.dfs: $(wildcard filesystem/*) $(AUDIO_OUTPUT_FILES)


### PR DESCRIPTION
I saw your post on N64brew's Discord, and tried to build the ROM myself. I encountered this error:

```
audioconv64 -o filesystem/audio/assets/audio/cleared_sound.wav
make: audioconv64: Permission denied 
make: *** [Makefile:28: assets/audio/cleared_sound.wav64] Error 127
```
This was fixed in my build environment by specifying the path to the tool. I added the change in this PR and wanted to share in case it helped anyone in the future. 

Disclaimer: I haven't tried the built ROM yet. 